### PR TITLE
#228-closingPopup

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -4,6 +4,7 @@ import Dialog from '@mui/material/Dialog'
 import IconButton from '@mui/material/IconButton'
 import CloseIcon from '@mui/icons-material/Close'
 import { PaperProps } from '@mui/material'
+import { useModalContext } from '~/context/modal-context'
 
 import useBreakpoints from '~/hooks/use-breakpoints'
 import { styles } from '~/components/popup-dialog/PopupDialog.styles'
@@ -22,6 +23,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
   closeModalAfterDelay
 }) => {
   const { isMobile } = useBreakpoints()
+  const { closeModal } = useModalContext()
 
   const handleMouseOver = () => timerId && clearTimeout(timerId)
   const handleMouseLeave = () => timerId && closeModalAfterDelay()
@@ -41,7 +43,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
         onMouseOver={handleMouseOver}
         sx={styles.box}
       >
-        <IconButton sx={styles.icon}>
+        <IconButton onClick={closeModal} sx={styles.icon}>
           <CloseIcon />
         </IconButton>
         <Box sx={styles.contentWraper}>{content}</Box>

--- a/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
+++ b/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
@@ -11,6 +11,7 @@ import { useSnackBarContext } from '~/context/snackbar-context'
 import { email } from '~/utils/validations/login'
 import loginImg from '~/assets/img/login-dialog/login.svg'
 import { login, snackbarVariants } from '~/constants'
+import { useEffect, useRef } from 'react'
 
 import styles from '~/containers/guest-home-page/login-dialog/LoginDialog.styles'
 
@@ -19,6 +20,7 @@ const LoginDialog = () => {
   const { closeModal } = useModalContext()
   const { setAlert } = useSnackBarContext()
   const [loginUser] = useLoginMutation()
+  const modalRef = useRef(null)
 
   const { handleSubmit, handleInputChange, handleBlur, data, errors } = useForm(
     {
@@ -38,8 +40,23 @@ const LoginDialog = () => {
     }
   )
 
+  useEffect(() => {
+    const handleOutsideClick = (e) => {
+      if (modalRef.current && !modalRef.current.contains(e.target)) {
+        if (!data.email && !data.password) {
+          closeModal()
+        }
+      }
+    }
+
+    document.addEventListener('mousedown', handleOutsideClick)
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick)
+    }
+  }, [data.email, data.password, closeModal])
+
   return (
-    <Box sx={styles.root}>
+    <Box ref={modalRef} sx={styles.root}>
       <Box sx={styles.imgContainer}>
         <Box alt='login' component='img' src={loginImg} sx={styles.img} />
       </Box>


### PR DESCRIPTION
Fix: Modal window closing behavior on Login popup

Implemented logic to close the Login popup when clicking outside the modal, but only if the fields are empty.
If the fields are not empty, the popup will close only when clicking the close button (cross).
![Screenshot_1](https://github.com/user-attachments/assets/527298a1-acd1-40cc-b64f-994ee845d249)
