### PR TITLE
Bugfix/230/logo button does not return to the home page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/src/containers/logo/Logo.tsx
+++ b/src/containers/logo/Logo.tsx
@@ -3,18 +3,23 @@ import logo from '~/assets/logo.svg'
 import logoLight from '~/assets/logo-light.svg'
 import Box, { BoxProps } from '@mui/material/Box'
 import { ComponentEnum } from '~/types'
+import HashLink from '~/components/hash-link/HashLink'
 
 interface LogoProps extends BoxProps {
   light?: boolean
 }
 
-const Logo: FC<LogoProps> = ({ light = false, ...props }) => (
-  <Box
-    alt='logo'
-    component={ComponentEnum.Img}
-    src={light ? logoLight : logo}
-    {...props}
-  />
-)
+const Logo: FC<LogoProps> = ({ light = false, ...props }) => {
+  return (
+    <HashLink to='#welcome'>
+      <Box
+        alt='logo'
+        component={ComponentEnum.Img}
+        src={light ? logoLight : logo}
+        {...props}
+      />
+    </HashLink>
+  )
+}
 
 export default Logo

--- a/src/tests/unit/components/search-input/SearchInput.spec.jsx
+++ b/src/tests/unit/components/search-input/SearchInput.spec.jsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import SearchInput from './SearchInput'
+import '@testing-library/jest-dom'
+
+describe('SearchInput component', () => {
+  const mockSetSearch = vi.fn()
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call setSearch when search icon is clicked', () => {
+    render(<SearchInput search='' setSearch={mockSetSearch} />)
+
+    const searchIcon = screen.getByTestId('search-icon')
+    fireEvent.click(searchIcon)
+
+    expect(mockSetSearch).toHaveBeenCalled()
+  })
+
+  it('should call setSearch with an empty string when delete icon is clicked', () => {
+    render(<SearchInput search='test' setSearch={mockSetSearch} />)
+
+    const deleteIcon = screen.getByTestId('delete-icon')
+    fireEvent.click(deleteIcon)
+
+    expect(mockSetSearch).toHaveBeenCalledWith('')
+  })
+
+  it('should call setSearch when enter is pressed', () => {
+    render(<SearchInput search='' setSearch={mockSetSearch} />)
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'new value' } })
+    fireEvent.keyPress(input, { key: 'Enter', code: 13, charCode: 13 })
+
+    expect(mockSetSearch).toHaveBeenCalledWith('new value')
+  })
+
+  it('should have hidden class if search is empty', () => {
+    render(<SearchInput search='' setSearch={mockSetSearch} />)
+
+    const deleteIcon = screen.getByTestId('delete-icon')
+    expect(deleteIcon).toHaveClass('hidden')
+  })
+
+  it('should have visible class if search is not empty', () => {
+    render(<SearchInput search='test' setSearch={mockSetSearch} />)
+
+    const deleteIcon = screen.getByTestId('delete-icon')
+    expect(deleteIcon).toHaveClass('visible')
+  })
+
+  it('should render text correctly', () => {
+    render(<SearchInput search='initial text' setSearch={mockSetSearch} />)
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveValue('initial text')
+  })
+})

--- a/src/tests/unit/components/search-input/SearchInput.spec.jsx
+++ b/src/tests/unit/components/search-input/SearchInput.spec.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
-import SearchInput from './SearchInput'
+import SearchInput from '~/components/search-input/SearchInput'
 import '@testing-library/jest-dom'
 
 describe('SearchInput component', () => {


### PR DESCRIPTION
Description: The “Space2Study” logo button does not return to the home page welcoming block after clicking it.
FIX: Wrapped the Box component (which displays the logo) with the HashLink component, making the logo a link to the #welcome section.
![Hashlink](https://github.com/user-attachments/assets/2b983303-568f-41ab-a8a5-cd62712550ea)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated ESLint code actions on save to apply only explicit fixes

- **New Features**
  - Added navigation to the logo component, enabling scrolling to the welcome section
  - Introduced comprehensive unit tests for the search input component

- **Tests**
  - Added test coverage for search input interactions, including icon clicks, key presses, and input rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->