### PR TITLE
Add tests for AppContentSwitcher component

### DIFF
--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -69,4 +69,25 @@ describe('AppContentSwitcher', () => {
     fireEvent.mouseOver(rightOption)
     expect(await screen.findByText('Tooltip Right')).toBeInTheDocument()
   })
+
+  it('should handle active=true correctly', () => {
+    const mockOnChange = vi.fn()
+
+    render(
+      <AppContentSwitcher
+        active
+        onChange={mockOnChange}
+        switchOptions={mockSwitchOptions}
+        typographyVariant='h6'
+      />
+    )
+
+    const inputElement = screen.getByTestId('switch').querySelector('input')
+
+    expect(inputElement).toHaveProperty('checked', true)
+
+    fireEvent.click(inputElement)
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
+
+const mockSwitchOptions = {
+  left: {
+    text: 'Option Left',
+    tooltip: 'Tooltip Left'
+  },
+  right: {
+    text: 'Option Right',
+    tooltip: 'Tooltip Right'
+  }
+}
+
+describe('AppContentSwitcher', () => {
+  it('should render with the correct props', () => {
+    render(
+      <AppContentSwitcher
+        active={false}
+        onChange={() => {}}
+        styles={{}}
+        switchOptions={mockSwitchOptions}
+        typographyVariant='h6'
+      />
+    )
+
+    expect(screen.getByText('Option Left')).toBeInTheDocument()
+    expect(screen.getByText('Option Right')).toBeInTheDocument()
+    expect(screen.getByTestId('switch')).toBeInTheDocument()
+  })
+
+  it('should call the onChange function when the switch is clicked', () => {
+    const mockOnChange = vi.fn()
+
+    render(
+      <AppContentSwitcher
+        active={false}
+        onChange={mockOnChange}
+        styles={{}}
+        switchOptions={mockSwitchOptions}
+        typographyVariant='h6'
+      />
+    )
+
+    const switchElement = screen.getByTestId('switch')
+    fireEvent.click(switchElement.querySelector('input'))
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('should render tooltips when tooltip props are passed', async () => {
+    render(
+      <AppContentSwitcher
+        active={false}
+        onChange={() => {}}
+        styles={{}}
+        switchOptions={mockSwitchOptions}
+        typographyVariant='h6'
+      />
+    )
+
+    const leftOption = screen.getByText('Option Left')
+    const rightOption = screen.getByText('Option Right')
+
+    fireEvent.mouseOver(leftOption)
+    expect(await screen.findByText('Tooltip Left')).toBeInTheDocument()
+
+    fireEvent.mouseOver(rightOption)
+    expect(await screen.findByText('Tooltip Right')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Added test cases for the AppContentSwitcher component:

- Renders correctly with the given props.

- Calls the onChange function when the switch is clicked.

- Renders tooltips when tooltip props are passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added comprehensive unit tests for the `AppContentSwitcher` component
	- Verified rendering, change events, tooltip functionality, and active state handling
	- Improved test coverage using `@testing-library/react` and `vitest`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->