### PR TITLE
bugfix/235/the-email-input-field-is-overlapped

### DIFF
--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
@@ -17,7 +17,7 @@ export const styles = {
   titleWithDescription: {
     wrapper: {
       textAlign: 'start',
-      m: 0
+      m: '0 0 24px 0'
     },
     title: {
       typography: 'h5',


### PR DESCRIPTION
![bugfix](https://github.com/user-attachments/assets/23f5ffd4-9c5d-4bcf-93d3-22dda156e706)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated margin styling for the title and description section on the forgot password page to improve visual spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->