### PR TITLE
#72/feature/createEmailConfirmationPopup

### DIFF
--- a/src/containers/email-confirm-modal/EmailConfirmModal.jsx
+++ b/src/containers/email-confirm-modal/EmailConfirmModal.jsx
@@ -5,6 +5,7 @@ import { useCallback } from 'react'
 import { useModalContext } from '~/context/modal-context'
 import { useTranslation } from 'react-i18next'
 import imgReject from '~/assets/img/email-confirmation-modals/not-success-icon.svg'
+import imgSuccess from '~/assets/img/email-confirmation-modals/success-icon.svg'
 import LoginDialog from '~/containers/guest-home-page/login-dialog/LoginDialog'
 import useAxios from '~/hooks/use-axios'
 import { AuthService } from '~/services/auth-service'
@@ -31,6 +32,25 @@ const EmailConfirmModal = ({ confirmToken, openModal }) => {
 
   if (loading) {
     return <Loader size={100} />
+  }
+
+  if (response && response.status === 'success') {
+    return (
+      <Box sx={styles.box}>
+        <ImgTitleDescription
+          img={imgSuccess}
+          style={styles}
+          title={t('modals.emailConfirm')}
+        />
+        <Button
+          onClick={openLoginDialog}
+          sx={{ ...styles.button, mt: '10px' }}
+          variant='contained'
+        >
+          {t('button.goToLogin')}
+        </Button>
+      </Box>
+    )
   }
 
   if (

--- a/src/tests/unit/containers/email-confirm-modal/EmailConfirmModal.spec.jsx
+++ b/src/tests/unit/containers/email-confirm-modal/EmailConfirmModal.spec.jsx
@@ -14,6 +14,25 @@ describe('EmailConfirmModal test', () => {
     closeModal: closeModal
   }
 
+  it('should render success image and message when email is confirmed', async () => {
+    const fakeData = {
+      error: null,
+      loading: false,
+      response: { status: 'success' }
+    }
+
+    useAxios.mockImplementation(() => fakeData)
+    renderWithProviders(<EmailConfirmModal {...props} />)
+
+    const modalImg = screen.getByAltText('info')
+    const title = screen.getByText('modals.emailConfirm')
+    const button = screen.getByRole('button', { name: 'button.goToLogin' })
+
+    expect(modalImg).toBeInTheDocument()
+    expect(title).toBeInTheDocument()
+    expect(button).toBeInTheDocument()
+  })
+
   it('should render negative-scenario image and message (BAD_CONFIRM_TOKEN)', async () => {
     const fakeData = {
       error: { code: 'BAD_CONFIRM_TOKEN' },


### PR DESCRIPTION
Description:

- Added a check for the successful scenario in the EmailConfirmModal component.
If response.status === 'success', the confirmation popup is rendered according to the design.

- Implemented a test to verify the scenario when the email is successfully confirmed.


![Screenshot_1](https://github.com/user-attachments/assets/7b1bc590-2beb-480c-a32a-b021b9d7c906)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a success state rendering for email confirmation
	- Introduced a new success screen with an icon, title, and login button when email is successfully confirmed

- **Tests**
	- Added a test case to verify the successful email confirmation rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->