### PR TITLE
#95-implementAddPhotoStep

### DIFF
--- a/src/components/drag-and-drop/DragAndDrop.jsx
+++ b/src/components/drag-and-drop/DragAndDrop.jsx
@@ -20,9 +20,9 @@ const DragAndDrop = ({
       onDragOver={dragStart}
       onDragStart={dragStart}
       onDrop={dragDrop}
-      sx={style.root}
+      sx={[style.root, isDrag && style.activeDrag]}
     >
-      <Box sx={[style.uploadBox, isDrag && style.activeDrag]}>{children}</Box>
+      <Box sx={[style.uploadBox]}>{children}</Box>
     </Box>
   )
 }

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -1,12 +1,89 @@
-import { Box } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
+import { useState } from 'react'
+import { useStepContext } from '~/context/step-context'
+import DragAndDrop from '~/components/drag-and-drop/DragAndDrop'
 
+import CloudUploadIcon from '@mui/icons-material/CloudUpload'
+import CheckIcon from '@mui/icons-material/Check'
 import { style } from '~/containers/tutor-home-page/add-photo-step/AddPhotoStep.style'
 
 const AddPhotoStep = ({ btnsBox }) => {
+  const [preview, setPreview] = useState(null)
+  const { handleStepData } = useStepContext()
+
+  const handleFileChange = ({ files, error }) => {
+    if (!error && files.length > 0) {
+      const file = files[0]
+      setPreview(URL.createObjectURL(file))
+
+      handleStepData('Photo', [file])
+    }
+  }
+
   return (
     <Box sx={style.root}>
-      AddPhoto step
-      {btnsBox}
+      <Box sx={style.imgContainer}>
+        <DragAndDrop
+          emitter={handleFileChange}
+          initialState={[]}
+          style={{
+            root: {
+              ...style.uploadBox,
+              border: preview ? 'none' : '2px dashed'
+            },
+            activeDrag: style.activeDrag
+          }}
+          validationData={{
+            maxQuantityFiles: 1,
+            filesTypes: ['image/jpeg', 'image/png']
+          }}
+        >
+          {preview ? (
+            <img alt='Preview' src={preview} style={style.img} />
+          ) : (
+            <Typography variant='body2'>Photo Preview</Typography>
+          )}
+        </DragAndDrop>
+      </Box>
+
+      <Box sx={style.rigthBox}>
+        <Typography sx={style.description} variant='body1'>
+          Velit officia consequat duis enim velit mollit. Exercitation veniam
+          consequat sunt nostrud amet.
+        </Typography>
+
+        <label htmlFor='upload-photo'>
+          <input
+            accept='image/*'
+            id='upload-photo'
+            onChange={(e) =>
+              handleFileChange({ files: e.target.files, error: null })
+            }
+            style={{ display: 'none' }}
+            type='file'
+          />
+          <Button
+            component='span'
+            startIcon={<CloudUploadIcon />}
+            sx={style.fileUploader.button}
+            variant='outlined'
+          >
+            Upload your profile photo
+          </Button>
+          {preview && (
+            <CheckIcon
+              color='success'
+              sx={{ ml: '19px', verticalAlign: 'middle' }}
+            />
+          )}
+        </label>
+
+        <Typography sx={{ mt: '10px' }} variant='body2'>
+          Maximum file size - 10 Mb
+        </Typography>
+
+        <Box sx={{ mt: 'auto' }}>{btnsBox}</Box>
+      </Box>
     </Box>
   )
 }

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.style.js
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.style.js
@@ -11,13 +11,16 @@ export const style = {
   },
   img: {
     width: '100%',
+    maxHeight: '440px',
     borderRadius: '20px',
+    objectFit: 'cover',
     mt: { xs: '20px', md: '0px' }
   },
   imgContainer: {
     display: 'flex',
     alignItems: 'center',
     maxWidth: '440px',
+    maxHeight: '440px',
     width: '100%',
     flex: 1,
     pb: { xs: '16px', sm: '26px', md: '52px' }


### PR DESCRIPTION
Implemented the final step in the stepper — addPhotoStep. The user can now upload a photo by clicking on the input or using drag-and-drop. The uploaded image is displayed in the left block.

![image](https://github.com/user-attachments/assets/3e05dfda-9e75-4ba4-ba17-54c7c1c32102)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the photo upload section with drag-and-drop support, an improved file validation mechanism, and live image previews.
  - Introduced a refined upload button with a success indicator for immediate feedback upon a successful image selection.

- **Style**
  - Improved the visual styling of the drag-and-drop interface to reflect active actions.
  - Updated image display with consistent sizing and cover-fit properties for a more polished appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->