### PR TITLE
Fixed incorrect text in General Info step

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -1,6 +1,6 @@
 {
   "generalInfo": {
-    "title": "Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint.",
+    "title": "Please complete the registration form for the best possible experience.",
     "textFieldLabel": "Describe in short your professional status",
     "helperText": "Inputs with the * sign are required"
   },


### PR DESCRIPTION
The description is matched to the mockup in the “General” step on the ‘Become a student’ pop-up. 
![image](https://github.com/user-attachments/assets/39602b3f-0d9a-45eb-9e17-97cae476fe1a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced user guidance by replacing a generic message with a clear call to complete the registration form for a better experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->